### PR TITLE
legendary 0.20.33 - fix missing bits

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ pywebview = [
     { version = "^3.6.3", extras = ["gtk"], platform = "linux", optional = true },
     { version = "^3.6.3", extras = ["gtk"], platform = "freebsd", optional = true },
 ]
-legendary-gl = "^0.20.32"
+legendary-gl = "^0.20.33"
 typing-extensions = "^4.3.0"
 
 [tool.poetry.scripts]

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r") as fh:
 
 requirements = [
     "requests<3.0",
-    "legendary-gl==0.20.32",
+    "legendary-gl==0.20.33",
     "setuptools",
     "wheel",
     "PyQt5",


### PR DESCRIPTION
Looks like setup.py and pyproject.toml have not been updated to support legendary 0.20.33. This should fix compilation for those still using setup.py and fix the install test in .rpm packages that checks for dependencies and says unmet dependencies by missing legendary-gl = 0.20.32

Patch tested by myself on OpenMandriva Cooker: https://github.com/OpenMandrivaAssociation/rare/commit/336e7510a173deed4ede1284d46280100f8b98da