### PR TITLE
LoadingWidget: Start playing movie once the widget is visible if `autostart` is enabled

### DIFF
--- a/rare/components/main_window.py
+++ b/rare/components/main_window.py
@@ -2,7 +2,7 @@ import os
 from logging import getLogger
 
 from PyQt5.QtCore import Qt, QSettings, QTimer, QSize, pyqtSignal, pyqtSlot
-from PyQt5.QtGui import QCloseEvent, QCursor, QShowEvent
+from PyQt5.QtGui import QCloseEvent, QCursor
 from PyQt5.QtWidgets import (
     QMainWindow,
     QApplication,

--- a/rare/components/tabs/games/game_widgets/game_widget.py
+++ b/rare/components/tabs/games/game_widgets/game_widget.py
@@ -111,7 +111,6 @@ class GameWidget(LibraryWidget):
             self.startTimer(random.randrange(42, 2361, 129), Qt.CoarseTimer)
             # self.startTimer(random.randrange(42, 2361, 363), Qt.VeryCoarseTimer)
             # self.rgame.load_pixmap()
-            # QTimer.singleShot(random.randrange(42, 2361, 7), Qt.VeryCoarseTimer, self.rgame.load_pixmap)
         super().paintEvent(a0)
 
     def timerEvent(self, a0):

--- a/rare/widgets/loading_widget.py
+++ b/rare/widgets/loading_widget.py
@@ -14,8 +14,7 @@ class LoadingWidget(QLabel):
         self.setMovie(self.movie)
         if self.parent() is not None:
             self.parent().installEventFilter(self)
-        if autostart:
-            self.movie.start()
+        self.autostart = autostart
 
     def __center_on_parent(self):
         rect = self.rect()
@@ -34,6 +33,9 @@ class LoadingWidget(QLabel):
     def showEvent(self, a0: QShowEvent) -> None:
         if a0.spontaneous():
             return super().showEvent(a0)
+        if self.autostart:
+            self.movie.start()
+            self.autostart = False
         self.__center_on_parent()
         super().showEvent(a0)
 
@@ -45,7 +47,8 @@ class LoadingWidget(QLabel):
 
     def start(self):
         self.setVisible(True)
-        self.movie.start()
+        if not self.autostart:
+            self.movie.start()
 
     def stop(self):
         self.setVisible(False)


### PR DESCRIPTION
Fixes a subtle bug that would cause increased CPU usage due to spawning multiple singleshot times with very short timeouts (15ms) until the Store tab was loaded.