### PR TITLE
RareGameSlim: fix uploading save games when there aren't any on the remote

### DIFF
--- a/rare/models/base_game.py
+++ b/rare/models/base_game.py
@@ -19,7 +19,7 @@ logger = getLogger("RareGameBase")
 
 @dataclass
 class RareSaveGame:
-    file: SaveGameFile
+    file: Optional[SaveGameFile]
     status: SaveGameStatus = SaveGameStatus.NO_SAVE
     dt_local: Optional[datetime] = None
     dt_remote: Optional[datetime] = None
@@ -236,8 +236,8 @@ class RareGameSlim(RareGameBase):
 
     @property
     def save_game_state(self) -> Tuple[SaveGameStatus, Tuple[Optional[datetime], Optional[datetime]]]:
-        if self.saves and self.save_path:
-            latest = self.latest_save
+        if self.save_path:
+            latest = s if (s := self.latest_save) is not None else RareSaveGame(None)
             # lk: if the save path wasn't known at startup, dt_local will be None
             # In that case resolve the save again before returning
             latest.status, (latest.dt_local, latest.dt_remote) = self.core.check_savegame_state(


### PR DESCRIPTION
If there aren't any saves for the game on the cloud, the game's saves list
is empty, and the first check failed. As a result the method would
erroneously report that there aren't any save games. This caused the
upload/download button in the cloud saves dialog and widget would be
disabled.

Fix it by removing the check and creating a fake save to satisfy
`check_savegame_state`
