### PR TITLE
Work-around versioning issues due to GH actions

### DIFF
--- a/.github/workflows/job_cx-freeze-appimage.yml
+++ b/.github/workflows/job_cx-freeze-appimage.yml
@@ -34,7 +34,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: |
           python3 freeze.py bdist_appimage

--- a/.github/workflows/job_cx-freeze-appimage.yml
+++ b/.github/workflows/job_cx-freeze-appimage.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Install build dependencies
         run: |
           sudo apt update

--- a/.github/workflows/job_cx-freeze-dmg.yml
+++ b/.github/workflows/job_cx-freeze-dmg.yml
@@ -40,7 +40,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: |
           python3 freeze.py bdist_dmg

--- a/.github/workflows/job_cx-freeze-dmg.yml
+++ b/.github/workflows/job_cx-freeze-dmg.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           cache: pip

--- a/.github/workflows/job_cx-freeze-msi.yml
+++ b/.github/workflows/job_cx-freeze-msi.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           cache: pip

--- a/.github/workflows/job_cx-freeze-msi.yml
+++ b/.github/workflows/job_cx-freeze-msi.yml
@@ -30,7 +30,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: |
           python3 freeze.py bdist_msi

--- a/.github/workflows/job_nuitka-linux.yml
+++ b/.github/workflows/job_nuitka-linux.yml
@@ -29,7 +29,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: >-
           python -m nuitka

--- a/.github/workflows/job_nuitka-linux.yml
+++ b/.github/workflows/job_nuitka-linux.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           cache: pip

--- a/.github/workflows/job_nuitka-macos.yml
+++ b/.github/workflows/job_nuitka-macos.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           cache: pip

--- a/.github/workflows/job_nuitka-macos.yml
+++ b/.github/workflows/job_nuitka-macos.yml
@@ -37,7 +37,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: >-
           arch -${{ matrix.arch }}

--- a/.github/workflows/job_nuitka-windows.yml
+++ b/.github/workflows/job_nuitka-windows.yml
@@ -29,7 +29,7 @@ jobs:
           pip3 install -r misc/requirements.in
       - name: Generate version information
         run: |
-          python3 -m setuptools_scm --force-write-version-files
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 -m setuptools_scm --force-write-version-files
       - name: Build
         run: >-
           python -m nuitka

--- a/.github/workflows/job_nuitka-windows.yml
+++ b/.github/workflows/job_nuitka-windows.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - uses: actions/setup-python@v5
         with:
           cache: pip

--- a/.github/workflows/job_pypi.yml
+++ b/.github/workflows/job_pypi.yml
@@ -26,7 +26,7 @@ jobs:
           pip3 install twine setuptools setuptools-scm
       - name: Build
         run: |
-          python3 setup.py sdist bdist_wheel
+          SETUPTOOLS_SCM_PRETEND_VERSION=${{ inputs.version }} python3 setup.py sdist bdist_wheel
       - name: Publish
         env:
           TWINE_USERNAME: __token__

--- a/.github/workflows/job_pypi.yml
+++ b/.github/workflows/job_pypi.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Set up Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/job_version.yml
+++ b/.github/workflows/job_version.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
       - name: Describe
         id: describe
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,103 +25,108 @@ jobs:
       - run: "true"
 
   pypi:
-    if: "!github.event.release.prerelease"
     name: PyPI
     uses: ./.github/workflows/job_pypi.yml
     secrets: inherit
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
 
   nuitka-linux:
     if: ${{ true }}
+    needs: version
     name: Nuitka Linux
     uses: ./.github/workflows/job_nuitka-linux.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   nuitka-linux-release:
-    needs: nuitka-linux
+    needs: [version, nuitka-linux]
     name: Nuitka Linux
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}.zip
-      name1: Rare-${{ github.ref_name }}-linux.zip
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}.zip
+      name1: Rare-${{ needs.version.outputs.version }}-linux.zip
 
   nuitka-macos:
     if: ${{ true }}
+    needs: version
     name: Nuitka MacOS
     uses: ./.github/workflows/job_nuitka-macos.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   nuitka-macos-release:
-    needs: nuitka-macos
+    needs: [version, nuitka-macos]
     name: Nuitka MacOS
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}-arm64.app.zip
-      name1: Rare-${{ github.ref_name }}-arm64-macos.app.zip
-      file2: Rare-${{ github.ref_name }}-x86_64.app.zip
-      name2: Rare-${{ github.ref_name }}-x86_64-macos.app.zip
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}-arm64.app.zip
+      name1: Rare-${{ needs.version.outputs.version }}-arm64-macos.app.zip
+      file2: Rare-${{ needs.version.outputs.version }}-x86_64.app.zip
+      name2: Rare-${{ needs.version.outputs.version }}-x86_64-macos.app.zip
 
   nuitka-windows:
     if: ${{ true }}
+    needs: version
     name: Nuitka Windows
     uses: ./.github/workflows/job_nuitka-windows.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   nuitka-windows-release:
-    needs: nuitka-windows
+    needs: [version, nuitka-windows]
     name: Nuitka Windows
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}.zip
-      name1: Rare-${{ github.ref_name }}-windows.zip
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}.zip
+      name1: Rare-${{ needs.version.outputs.version }}-windows.zip
 
   cx-freeze-appimage:
     if: ${{ true }}
+    needs: version
     name: cx-Freeze AppImage
     uses: ./.github/workflows/job_cx-freeze-appimage.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   cx-freeze-appimage-release:
-    needs: cx-freeze-appimage
+    needs: [version, cx-freeze-appimage]
     name: cx-Freeze AppImage
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}.AppImage
-      name1: Rare-${{ github.ref_name }}.AppImage
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}.AppImage
+      name1: Rare-${{ needs.version.outputs.version }}.AppImage
 
   cx-freeze-dmg:
     if: ${{ true }}
+    needs: version
     name: cx-Freeze MacOS
     uses: ./.github/workflows/job_cx-freeze-dmg.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   cx-freeze-dmg-release:
-    needs: cx-freeze-dmg
+    needs: [version, cx-freeze-dmg]
     name: cx-Freeze MacOS
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}-arm64.dmg
-      name1: Rare-${{ github.ref_name }}-arm64.dmg
-      file2: Rare-${{ github.ref_name }}-x86_64.dmg
-      name2: Rare-${{ github.ref_name }}-x86_64.dmg
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}-arm64.dmg
+      name1: Rare-${{ needs.version.outputs.version }}-arm64.dmg
+      file2: Rare-${{ needs.version.outputs.version }}-x86_64.dmg
+      name2: Rare-${{ needs.version.outputs.version }}-x86_64.dmg
 
   cx-freeze-msi:
     if: ${{ true }}
+    needs: version
     name: cx-Freeze Windows
     uses: ./.github/workflows/job_cx-freeze-msi.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ needs.version.outputs.version }}
   cx-freeze-msi-release:
-    needs: cx-freeze-msi
+    needs: [version, cx-freeze-msi]
     name: cx-Freeze Windows
     uses: ./.github/workflows/job_publish.yml
     with:
-      version: ${{ github.ref_name }}
-      file1: Rare-${{ github.ref_name }}.msi
-      name1: Rare-${{ github.ref_name }}.msi
+      version: ${{ needs.version.outputs.version }}
+      file1: Rare-${{ needs.version.outputs.version }}.msi
+      name1: Rare-${{ needs.version.outputs.version }}.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,13 @@ permissions:
 
 jobs:
 
+  version:
+    name: Describe
+    uses: ./.github/workflows/job_version.yml
+
   title:
-    name: Version ${{ github.ref_name }}
+    needs: version
+    name: Version ${{ needs.version.outputs.version }}
     runs-on: ubuntu-latest
     steps:
       - run: "true"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -60,7 +60,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   nuitka-linux-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, nuitka-linux]
+    needs: [version, nuitka-linux, prerelease]
     name: Nuitka Linux
     uses: ./.github/workflows/job_publish.yml
     with:
@@ -77,7 +77,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   nuitka-macos-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, nuitka-macos]
+    needs: [version, nuitka-macos, prerelease]
     name: Nuitka MacOS
     uses: ./.github/workflows/job_publish.yml
     with:
@@ -96,7 +96,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   nuitka-windows-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, nuitka-windows]
+    needs: [version, nuitka-windows, prerelease]
     name: Nuitka Windows
     uses: ./.github/workflows/job_publish.yml
     with:
@@ -113,7 +113,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   cx-freeze-appimage-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, cx-freeze-appimage]
+    needs: [version, cx-freeze-appimage, prerelease]
     name: cx-Freeze AppImage
     uses: ./.github/workflows/job_publish.yml
     with:
@@ -130,7 +130,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   cx-freeze-dmg-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, cx-freeze-dmg]
+    needs: [version, cx-freeze-dmg, prerelease]
     name: cx-Freeze MacOS
     uses: ./.github/workflows/job_publish.yml
     with:
@@ -149,7 +149,7 @@ jobs:
       version: ${{ needs.version.outputs.version }}
   cx-freeze-msi-release:
     if: ${{ inputs.prerelease }}
-    needs: [version, prerelease, cx-freeze-msi]
+    needs: [version, cx-freeze-msi, prerelease]
     name: cx-Freeze Windows
     uses: ./.github/workflows/job_publish.yml
     with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ git_describe_command = [ "git", "describe", "--dirty", "--long" ]
 version_scheme = "misc.mkversion:mknumeric"
 local_scheme = "no-local-version"
 version_file = "rare/_version.py"
-fallback_version = "1.11.1.0"
+fallback_version = "1.11.2.0"
 
 [tool.nuitka]
 assume-yes-for-downloads = true
@@ -115,8 +115,8 @@ output-filename = "Rare.exe"
 file-description = "Rare.exe"
 company-name = "RareDevs"
 product-name = "Rare"
-file-version = "1.11.1.0"
-product-version = "1.11.1.0"
+file-version = "1.11.2.0"
+product-version = "1.11.2.0"
 windows-console-mode = "disable"
 windows-icon-from-ico = "rare/resources/images/Rare.ico"
 
@@ -134,7 +134,7 @@ force-exclude = '''
 
 [tool.poetry]
 name = "Rare"
-version = "1.11.1.0"
+version = "1.11.2.0"
 authors = [
     "Dummerle 44114474+Dummerle@users.noreply.github.com",
     "loathingKernel 142770+loathingKernel@users.noreply.github.com",


### PR DESCRIPTION
- **workflows: set `fetch-tags` to true**
- **workflows: describe version for release**
- **workflows: use SETUPTOOLS_SCM_PRETEND_VERSION= to work-around GH Actions issues**
- **Release 1.11.2 (Boga Discus) (Hotfix 2)**
