### PR TITLE
chore: remove `version_scheme` from `pyproject.toml`

### DIFF
--- a/.github/workflows/_job_cx-freeze-appimage.yml
+++ b/.github/workflows/_job_cx-freeze-appimage.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install patchelf fakeroot
-          pip3 install --upgrade cx_freeze==7.2.10 ruff
+          pip3 install --upgrade cx_freeze ruff
       - name: Install target dependencies
         run: |
           pip3 install -r misc/requirements.in

--- a/.github/workflows/_job_cx-freeze-dmg.yml
+++ b/.github/workflows/_job_cx-freeze-dmg.yml
@@ -34,7 +34,7 @@ jobs:
           architecture: ${{ matrix.pyarch }}
       - name: Install build dependencies
         run: |
-          pip3 install --upgrade cx_freeze==7.2.10 ruff
+          pip3 install --upgrade cx_freeze ruff
       - name: Install target dependencies
         run: |
           pip3 install -r misc/requirements.in

--- a/.github/workflows/_job_cx-freeze-msi.yml
+++ b/.github/workflows/_job_cx-freeze-msi.yml
@@ -24,7 +24,7 @@ jobs:
           architecture: x64
       - name: Install build dependencies
         run: |
-          pip3 install --upgrade cx_freeze==7.2.10 ruff
+          pip3 install --upgrade cx_freeze ruff
       - name: Install target dependencies
         run: |
           pip3 install -r misc/requirements.in

--- a/README.md
+++ b/README.md
@@ -142,10 +142,16 @@ For build and install the package manually, run `python setup.py bdist_wheel` an
 ## Contributing
 There are several options to contribute.
 
-- If you know Python and PyQt, you can implement new features (Some ideas are in the projects tab).
+- If you know Python and Qt, you can implement new features (Some ideas are in the projects tab).
 - You can translate the application in your language: Check our [transifex](https://www.transifex.com/rare-1/rare) page for that.
 
 More information is available in CONTRIBUTING.md.
+
+### Run from source for developmenmt purposes
+1. Clone the repo: `git clone https://github.com/RareDevs/Rare.git`.
+2. Change your working directory to the project folder: `cd Rare`.
+3. Run `pip install -e .` to install Rare in editable mode along with any required runtime dependencies.
+4. External tools used for development can be installed by running `pip install -e .[dev]` instead.
 
 
 ## Reporting issues

--- a/misc/requirements-dev.in
+++ b/misc/requirements-dev.in
@@ -3,3 +3,4 @@ mypy
 black[d]
 PySide6-stubs
 qstylizer
+ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dev = [
     "black[d]",
     "PySide6-stubs",
     "qstylizer",
+    "ruff",
 ]
 packaging = [
     "cx-freeze",
@@ -88,7 +89,7 @@ version = { attr = "rare.__version__" }
 # use only annotated tags ( omit `--tags` argument from `git describe`)
 git_describe_command = [ "git", "describe", "--dirty", "--long" ]
 #tag_regex = "(?P<version>^[0-9]+\\.[0-9]+\\.[0-9]+)(?P<suffix>.[0-9]+)?$"
-version_scheme = "misc.mkversion:mknumeric"
+#version_scheme = "misc.mkversion:mknumeric"
 local_scheme = "no-local-version"
 version_file = "rare/_version.py"
 fallback_version = "1.11.3.0"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from setuptools import setup
-
 from setuptools_scm import ScmVersion
 
 


### PR DESCRIPTION
Using `pip install .` or `python -m build` fails if this directive it
present. Both of these commands work correctly without the directive by
using a barebones `setup.py`.

On the other hand, removing this directive breaks
`python3 -m setuptools_scm --force-write-version-files` which is used
in the workflows to generate `rare/_version.py` before packaging. In the
case of the workflows though we already override the version using
`SETUPTOOLS_SCM_PRETEND_VERSION` so it shouldn't be an issue.

