### PR TITLE
paths: update `get_rare_executable()` to handle Flatpak and Snap packaging

### DIFF
--- a/rare/utils/paths.py
+++ b/rare/utils/paths.py
@@ -243,8 +243,22 @@ def desktop_link_path(link_name: str, link_type: str) -> Path:
     return __link_type[link_type].joinpath(f"{link_name}.{__link_suffix[platform.system()]['link']}")
 
 
-def get_rare_executable() -> List[str]:
+def get_rare_executable(*, external: bool = False) -> List[str]:
+    """
+    Returns the command list to invoke Rare for different platforms and packaging solutions
+    When used with container based packaging, such as Flatpak or Snap, returns the command
+    invoke Rare outside of the container
+
+    :param external: if True return the command to invoke Rare through Flatpak or Snap, defaults to false
+    :return: command list
+    """
     logger.debug(f"Trying to find executable: {sys.executable}, {sys.argv}")
+
+    if os.environ.get("SNAP") and external:
+        return ["snap", "run", "rare"]
+    if os.environ.get("container") == "flatpak" and external:
+        return ["flatpak",  "run", "io.github.dummerle.rare"]
+
     # lk: detect if nuitka
     if "__compiled__" in globals():
         executable = [sys.executable]
@@ -324,7 +338,7 @@ def create_desktop_link(app_name: str, app_title: str = "", link_name: str = "",
         logger.info(f"Creating shortcut for {app_title} at {shortcut_path}")
 
     if platform.system() in {"Linux", "FreeBSD"}:
-        executable = get_rare_executable()
+        executable = get_rare_executable(external=True)
         executable = shlex.join(executable)
         if not for_rare:
             executable = f"{executable} launch {app_name}"
@@ -370,3 +384,5 @@ def create_desktop_link(app_name: str, app_title: str = "", link_name: str = "",
 
         shortcut.save()
         return True
+
+    return False

--- a/rare/utils/steam_shortcuts.py
+++ b/rare/utils/steam_shortcuts.py
@@ -152,7 +152,7 @@ def add_steam_shortcut(app_name: str, app_title: str) -> SteamShortcut:
         logger.info("Removing old Steam shortcut for %s", app_name)
         remove_steam_shortcut(app_name)
 
-    command = get_rare_executable()
+    command = get_rare_executable(external=True)
     arguments = ["launch", app_name]
     if len(command) > 1:
         arguments = command[1:] + arguments


### PR DESCRIPTION
In the case of desktop shortcuts or Steam shortcuts we need to invoke the
Flatpak or Snap packages in their respective ways since we are not already
in the container. For these cases we need `get_rare_executable` to return
the command to run Rare externally.

There are other cases when we need to invoke one of Rare's sub-applications
from inside the container that we don't need to do this, hence the `external`
parameter was introduced.

Fixes: [RareDevs/Rare#609](https://github.com/RareDevs/Rare/issues/609)

Co-Authored-By: Kyuyrii [kyuyriibyakko@gmail.com](mailto:kyuyriibyakko@gmail.com)