### PR TITLE
LocalLaunchSettings: set `LEGENDARY_WRAPPER_EXE` to `0` if global is enabled

### DIFF
--- a/rare/commands/launcher/lgd_helper.py
+++ b/rare/commands/launcher/lgd_helper.py
@@ -117,9 +117,9 @@ def get_game_params(rgame: RareGameSlim, init: InitParams, launch: LaunchParams)
     full_params = []
     full_params.extend(params.launch_command)
     if 'LEGENDARY_WRAPPER_EXE' in params.environment:
-        lgd_wrapper = params.environment.pop('LEGENDARY_WRAPPER_EXE', '').strip()
-        if lgd_wrapper and os.path.isfile(lgd_wrapper):
-            full_params.append(lgd_wrapper)
+        wrapper = params.environment.pop('LEGENDARY_WRAPPER_EXE', '').strip()
+        if wrapper.endswith('.exe') and os.path.isfile(wrapper):
+            full_params.append(wrapper)
     full_params.append(os.path.join(params.game_directory, params.game_executable))
     full_params.extend(params.game_parameters)
     full_params.extend(params.egl_parameters)

--- a/rare/components/tabs/library/details/game.py
+++ b/rare/components/tabs/library/details/game.py
@@ -132,7 +132,8 @@ class LocalLaunchSettings(LaunchSettingsBase):
     def _lgd_wrapper_check_changed(self, state: Qt.CheckState):
         _wrapper = str(wrapper_path())
         config.adjust_envvar_with_global(
-            self.app_name, 'LEGENDARY_WRAPPER_EXE', _wrapper if state == Qt.CheckState.Checked else ''
+            self.app_name, 'LEGENDARY_WRAPPER_EXE',
+            _wrapper if state == Qt.CheckState.Checked else '0' if config.get_envvar('default', 'LEGENDARY_WRAPPER_EXE') else ''
         )
         self.environ_changed.emit('LEGENDARY_WRAPPER_EXE')
 


### PR DESCRIPTION
Fixes the wrapper getting enabled because of falsey evaluation of the local
environment value
